### PR TITLE
[WIP] Lazyily load images when they scroll into view

### DIFF
--- a/app/components/history-item.js
+++ b/app/components/history-item.js
@@ -24,12 +24,6 @@ export default Component.extend({
     return remoteStorage.shares.getThumbnailURL(this.get('name'));
   }.property('name'),
 
-  itemStyle: function() {
-    if (this.get('isImage')) {
-      return Ember.String.htmlSafe(`background-image:url(${this.get('thumbnailUrl')});background-color:#ccc`);
-    }
-  }.property('url'),
-
   nameWithoutTimestamp: function() {
     return this.get('name').substr(12);
   }.property('name'),

--- a/app/routes/history.js
+++ b/app/routes/history.js
@@ -48,14 +48,23 @@ function initializeLazyLoader() {
 }
 
 function startSpinner() {
-  let el = Ember.$('.b-lazy');
-
-  el.spin({
-    length    : 10,
-    width     : 5,
-    radius    : 15,
+  const el = Ember.$('.b-lazy');
+  const options = {
+    length    : 20,
+    height    : 200,
+    width     : 4,
+    radius    : 20,
+    color     : '#eee',
     className : 'spinner',
-    top       : '70',
-    left      : '70'
-  });
+    top       : 'auto',
+    left      : 'auto'
+  };
+
+  // TODO use some method/property (was App.isSmallScreen)
+  if (window.innerWidth <= 640) {
+    options.height = 120;
+    options.width = 3;
+  }
+
+  el.spin(options);
 }

--- a/app/routes/history.js
+++ b/app/routes/history.js
@@ -1,3 +1,4 @@
+/* global Blazy */
 import Ember from 'ember';
 
 export default Ember.Route.extend({
@@ -23,6 +24,14 @@ export default Ember.Route.extend({
       });
 
       return shares;
+    });
+  },
+
+  setupController() {
+    this._super(...arguments);
+
+    Ember.run.scheduleOnce('afterRender', function() {
+      new Blazy(); // initialize image lazy loading library
     });
   }
 

--- a/app/routes/history.js
+++ b/app/routes/history.js
@@ -31,8 +31,31 @@ export default Ember.Route.extend({
     this._super(...arguments);
 
     Ember.run.scheduleOnce('afterRender', function() {
-      new Blazy(); // initialize image lazy loading library
+      initializeLazyLoader();
+      startSpinner();
     });
-  }
+  },
+
 
 });
+
+function initializeLazyLoader() {
+  new Blazy({
+    success: function(elem) {
+      Ember.$(elem).children('.spinner').remove();
+    }
+  });
+}
+
+function startSpinner() {
+  let el = Ember.$('.b-lazy');
+
+  el.spin({
+    length    : 10,
+    width     : 5,
+    radius    : 15,
+    className : 'spinner',
+    top       : '70',
+    left      : '70'
+  });
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -170,6 +170,7 @@ section.file-dropzone.has-file-to-upload {
         background-size: cover;
         background-position: center;
         background-repeat: no-repeat;
+        background-color: #ccc;
         border-radius: 5px;
         &.generic-file {
           background-image: url(/assets/images/document.svg);

--- a/app/templates/components/history-item.hbs
+++ b/app/templates/components/history-item.hbs
@@ -1,5 +1,5 @@
 {{#if isImage}}
-  <div class="image" style={{itemStyle}}></div>
+  <div class="image b-lazy" data-src={{thumbnailUrl}}></div>
 {{else}}
   <div class="image generic-file">
     <p class="meta">{{nameWithoutTimestamp}}</p>

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
   "name": "sharesome",
   "dependencies": {
     "vex": "~1.3.5",
-    "remotestorage": "~0.14.0"
+    "remotestorage": "~0.14.0",
+    "bLazy": "blazy#^1.8.2"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -25,6 +25,7 @@ module.exports = function(defaults) {
 
   app.import('bower_components/remotestorage/release/stable/remotestorage-nocache.js');
   app.import('bower_components/vex/js/vex.combined.min.js');
+  app.import('bower_components/bLazy/blazy.js');
   app.import('vendor/remotestorage/remotestorage-sharesome.js');
   app.import('vendor/spin-js/spin.min.js');
   app.import('vendor/spin-js/jquery.spin.js');

--- a/tests/integration/components/history-item-test.js
+++ b/tests/integration/components/history-item-test.js
@@ -26,7 +26,7 @@ test('it renders images', function(assert) {
 
   this.render(hbs`{{history-item item=item}}`);
 
-  assert.equal(this.$('div.image').attr('style').match(/url\((.+)\)/)[1],
+  assert.equal(this.$('div.image').attr('data-src'),
                'https://storage.kosmos.org/public/shares/thumbnails/foobar.jpg');
 
   // Handle any actions with this.on('myAction', function(val) { ... });" + EOL + EOL +


### PR DESCRIPTION
Most of the time when opening the app it's for viewing or getting the URL of one of the most recently uploaded images. Recently I was getting more and more annoyed that the history view always loads all the images. Especially when using the app on a mobile.

This PR introduces lazy loading of the images when they scroll into view.