### PR TITLE
Fix iOS clicks

### DIFF
--- a/app/components/history-item.js
+++ b/app/components/history-item.js
@@ -39,8 +39,7 @@ export default Component.extend({
   click: function() {
     // TODO use App.isSmallScreen
     if (window.innerWidth <= 640) {
-      var overlayIsVisible = this.get('overlayIsVisible');
-      this.set('overlayIsVisible', !overlayIsVisible);
+      this.toggleProperty('overlayIsVisible');
     }
   },
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -159,6 +159,7 @@ section.file-dropzone.has-file-to-upload {
     @include clearfix();
     list-style: none;
     li {
+      cursor: pointer;
       position: relative;
       float: left;
       margin: 0 1rem 2rem 1rem;


### PR DESCRIPTION
Fixes #57 

I found that on iOS, elements that are not links or buttons need to have a `cursor: pointer` set in order to trigger click events.